### PR TITLE
Enhancement - python3

### DIFF
--- a/BETRS.py
+++ b/BETRS.py
@@ -325,7 +325,7 @@ class Model():
                 write_bigDlist_txt(self.bigDlist, fn2, fn3,fn4,fn5,self) #FY                
                 print('wrote D-value - matrices to %s\n') % (fn2)
                 print('wrote D-value - matrices to %s\n') % (fn3)
-		print('wrote D-value - matrices to %s\n') % (fn4)
+                print('wrote D-value - matrices to %s\n') % (fn4)
                 print('wrote D-value - matrices to %s\n') % (fn5)
                 # end of modification
 

--- a/LinFluxApprox.py
+++ b/LinFluxApprox.py
@@ -27,11 +27,11 @@ def mkFluxkey(m, flowmat, procmat, lat=12, lon=24, use_correction=False):
             for medium in range(10):
                 keylist[season][comp].append({})
 
-    for pkey in procmat.keys():
+    for pkey in list(procmat.keys()):
         key, medium = match_keys(pkey)
         for comp in range (len(procmat[pkey])):
             for season in range(len(procmat[pkey][comp])):                
-                if key in keylist[season][comp][medium].keys():
+                if key in list(keylist[season][comp][medium].keys()):
                     keylist[season][comp][medium][key] += procmat[pkey][comp][season]
                 else:
                     keylist[season][comp][medium][key] = procmat[pkey][comp][season]
@@ -40,42 +40,42 @@ def mkFluxkey(m, flowmat, procmat, lat=12, lon=24, use_correction=False):
         '''The following calculate 'pseudo dilution'=D-DQn+1 and flow_Q transport which instead the flow transport. added by Fangyuan, 2rd Dec., 2016'''                    
         flowmatQ=mkflowQ(m)
         #calculate flow_Q transport 
-        for fkeyQ in  flowmatQ.keys():
+        for fkeyQ in  list(flowmatQ.keys()):
             key="flux"
             medium = fkeyQ[0]-1
             for entry in flowmatQ[fkeyQ]:
                 comp = int(entry[0])-1            
                 for i in range (2,14):
                     season=i-2
-                    if key in keylist[season][comp][medium].keys():
+                    if key in list(keylist[season][comp][medium].keys()):
                         keylist[season][comp][medium][(key,entry[1])] += entry[i]
                     else:
                         keylist[season][comp][medium][(key,entry[1])] = entry[i]                    
                     
         # remove intra-cell flows
-        for [k,v] in flowmat.items():
+        for [k,v] in list(flowmat.items()):
             intercell=list(where(v[:,0]!=v[:,1])[0])
             intracell=list(where(v[:,0]==v[:,1])[0])
             flowmat[k]=v[intercell,:]    
         #calculate 'pseudo dilution'=D-DQn+1
-        for [k,v] in flowmatQ.items():
-            for [kk,vv] in flowmat.items():
+        for [k,v] in list(flowmatQ.items()):
+            for [kk,vv] in list(flowmat.items()):
                 if k==kk:
                     v[:,2:14]=vv[:,2:14]-v[:,2:14]   
         #change pseudo dilution in keylist form
-        for fkeyQ in  flowmatQ.keys():
+        for fkeyQ in  list(flowmatQ.keys()):
             key="dilution"
             medium = fkeyQ[0]-1
             for entry in flowmat[fkeyQ]:
                 comp = int(entry[0])-1
                 for i in range (2,14):
                     season=i-2
-                    if key in keylist[season][comp][medium].keys():
+                    if key in list(keylist[season][comp][medium].keys()):
                         keylist[season][comp][medium][(key,entry[1])] += entry[i]
                     else:
                         keylist[season][comp][medium][(key,entry[1])] = entry[i]
     else:
-        for fkey in  flowmat.keys():
+        for fkey in  list(flowmat.keys()):
             key="Flux"
             medium = fkey[0]-1
             for entry in flowmat[fkey]:
@@ -85,7 +85,7 @@ def mkFluxkey(m, flowmat, procmat, lat=12, lon=24, use_correction=False):
                     continue
                 for i in range (2,14):
                     season=i-2
-                    if key in keylist[season][comp][medium].keys():
+                    if key in list(keylist[season][comp][medium].keys()):
                         keylist[season][comp][medium][(key,entry[1])] += entry[i]
                     else:
                         keylist[season][comp][medium][(key,entry[1])] = entry[i]
@@ -99,7 +99,7 @@ def mkDdiag_from_Fluxkey(fluxkey):
     for i1 in range(len(fluxkey)):
         for i2 in range(len(fluxkey[i1])):
             for i3 in range(len(fluxkey[i1][i2])):
-                for key in fluxkey[i1][i2][i3].keys():
+                for key in list(fluxkey[i1][i2][i3].keys()):
                     Ddiag[i1,i2*11+i3] += fluxkey[i1][i2][i3][key] 
     return Ddiag    
 

--- a/Output/BDE209_dyn_br/summary.txt
+++ b/Output/BDE209_dyn_br/summary.txt
@@ -8,3 +8,5 @@ constparfile const_parameters_20C3M.comp.ivm_corrdiffstrato_7scenarios_br.txt
 flowdirectory OcMix.At100_20C3M.a2.comp.ivm_br
 procfile processes_separate_particles_from_gas.txt
 contfile control_default.txt
+emisfile annual/Emission_BDE209_10_comparts/2027.txt
+solvfile Solver/solvparams_default.txt

--- a/PY/processes.py
+++ b/PY/processes.py
@@ -39,8 +39,8 @@ class process():
             try:
                 getattr(self,p)
             except AttributeError:
-                print("processes.py: "
-                      +"Method %s not implemented !\n Aborting!") % (p)
+                print(("processes.py: "
+                      +"Method %s not implemented !\n Aborting!") % (p))
                 sys.exit(1)
 
     def getD(self):
@@ -55,7 +55,7 @@ class process():
         # don't change this
         D={}
         procname=inspect.getframeinfo(inspect.currentframe())[2]
-        for c in self.m.compdict.keys():
+        for c in list(self.m.compdict.keys()):
             D[(c,c,procname)]=self.m.chempardict[c]['k_reac']\
                                  *self.m.vdict[c]['bulk']\
                                  *self.m.zdict[c]['bulk']
@@ -507,13 +507,13 @@ class process():
                            *(self.m.par['fcp1']/vp)*self.m.vdict[1]['bulk']\
                            *self.m.zdict[1]['bulk']
         D[(1,8,procname)]=td
-	D[(8,1,procname)]=D[(1,8,procname)]
-	'''
+        D[(8,1,procname)]=D[(1,8,procname)]
+        '''
         time=1e-1
         td=minimum(td,self.m.vdict[1]['bulk']*self.m.zdict[1]['bulk']/time)
         D[(1,8,procname)]=minimum(td,self.m.vdict[8]['bulk']*self.m.zdict[8]['bulk']/time)
         D[(8,1,procname)]=D[(1,8,procname)]
-	'''
+        '''
         return(D)
 
     def betr_air2_faerosol2_exchange(self):
@@ -535,13 +535,13 @@ class process():
                            *(self.m.par['ffp2']/vp)*self.m.vdict[2]['bulk']\
                            *self.m.zdict[2]['bulk']
         D[(2,9,procname)]=td
-	D[(9,2,procname)]=D[(2,9,procname)]
-	'''  
+        D[(9,2,procname)]=D[(2,9,procname)]
+        '''  
         time=1e-1
         td=minimum(td,self.m.vdict[2]['bulk']*self.m.zdict[2]['bulk']/time)
         D[(2,9,procname)]=minimum(td,self.m.vdict[9]['bulk']*self.m.zdict[9]['bulk']/time)
         D[(9,2,procname)]=D[(2,9,procname)]
-	'''
+        '''
         return(D)
 
     def betr_air2_caerosol2_exchange(self):
@@ -560,13 +560,13 @@ class process():
                            *(self.m.par['fcp2']/vp)*self.m.vdict[2]['bulk']\
                            *self.m.zdict[2]['bulk']
         D[(2,10,procname)]=td
-	D[(10,2,procname)]=D[(2,10,procname)]
-	'''
+        D[(10,2,procname)]=D[(2,10,procname)]
+        '''
         time=1e-1
         td=minimum(td,self.m.vdict[2]['bulk']*self.m.zdict[2]['bulk']/time)
         D[(2,10,procname)]=minimum(td,self.m.vdict[10]['bulk']*self.m.zdict[10]['bulk']/time)
         D[(10,2,procname)]=D[(2,10,procname)]
-	'''
+        '''
         return(D)
     
     def betr_caerosol1_drydep(self):

--- a/PY/volumes.py
+++ b/PY/volumes.py
@@ -27,8 +27,8 @@ class Volumes():
         empty=[]
         for i in arange(0,len(compdict)):
             empty.append({})
-        self.V=dict(zip(self.compdict.keys(), empty))
-        for c in self.compdict.keys():
+        self.V=dict(list(zip(list(self.compdict.keys()), empty)))
+        for c in list(self.compdict.keys()):
             try:
                 self.V[c]=getattr(self,'V'+str(c))()
             except AttributeError:

--- a/PY/zvalues.py
+++ b/PY/zvalues.py
@@ -31,8 +31,8 @@ class Zvalues():
         empty=[]
         for i in arange(0,len(compdict)):
             empty.append({})
-        self.Z=dict(zip(self.compdict.keys(), empty))       
-        for c in self.compdict.keys():
+        self.Z=dict(list(zip(list(self.compdict.keys()), empty)))       
+        for c in list(self.compdict.keys()):
             try:
                 self.Z[c]=getattr(self,'Z'+str(c))()
             except AttributeError:

--- a/emissions.py
+++ b/emissions.py
@@ -22,7 +22,7 @@ class Emission:
         try:
             f=open(fn, 'r')
         except IOError:
-            print("emissions.py: emission file %s not found. Aborting!") % (fn)
+            print(("emissions.py: emission file %s not found. Aborting!") % (fn))
             sys.exit(1)
         lines=f.readlines()
         f.close

--- a/helpers.py
+++ b/helpers.py
@@ -92,7 +92,7 @@ def tocell(reg,comp,m):
 def calQ(comp,cell,m):
     dk=zeros((2,m.nocells,12))
     x=zeros(12)
-    for [k,v] in m.Dproc.items():
+    for [k,v] in list(m.Dproc.items()):
         key=k[0]-1
         mstring = k[2]
         if re.search("deg|wet|disso", mstring): 

--- a/helpers3.py
+++ b/helpers3.py
@@ -17,10 +17,10 @@ def normalizefluxkey(flux_key):
         for ii in range(len(flux_key[i])):
             for iii in range(len(flux_key[i][ii])):
                 fsum=0.0
-                for key in flux_key[i][ii][iii].keys():
+                for key in list(flux_key[i][ii][iii].keys()):
                     fsum += flux_key[i][ii][iii][key]
                 if fsum !=0.0:
-                    for key in flux_key[i][ii][iii].keys():
+                    for key in list(flux_key[i][ii][iii].keys()):
                         flux_key[i][ii][iii][key] = flux_key[i][ii][iii][key]/fsum
     return flux_key
                     

--- a/mkDmixQ.py
+++ b/mkDmixQ.py
@@ -25,11 +25,11 @@ def mkDmixQ(m):
     Qmix=zeros((2,cells,seasons))
 
     ''' uses zdict and vdict to construct vz'''
-    for c in m.compdict.keys():
+    for c in list(m.compdict.keys()):
         vz[c-1]=m.zdict[c]['bulk']*m.vdict[c]['bulk']
         
     '''T in mixing process'''        
-    for [k,v] in m.Dproc.items():
+    for [k,v] in list(m.Dproc.items()):
         key=k[0]-1
         mstring = k[2]
         if re.search("mix", mstring): 
@@ -37,7 +37,7 @@ def mkDmixQ(m):
            if key==1: T[1]=m.par['h2']/m.par['mixing21']
 
     '''Kloss'''  
-    for [k,v] in m.Dproc.items():
+    for [k,v] in list(m.Dproc.items()):
         key=k[0]-1
         mstring = k[2]
         if re.search("deg|wet|disso", mstring): 

--- a/mkbigD.py
+++ b/mkbigD.py
@@ -267,7 +267,7 @@ def mkbigD(m, track_flows=False ,use_correction=False):
         if m.shape != matshp:
             print("mkbigD: inconsistent matrix dimensions. Aborting!\n")
             sys.exit(1)
-	
+
     # add matrices for intercell transport  and intracell processes 
     matlist=[]; outbigD=[]
     if use_correction==True:
@@ -277,7 +277,7 @@ def mkbigD(m, track_flows=False ,use_correction=False):
         outbigD.append(matlist_flow[ts]+matlist_proc[ts])
         if use_correction==True:
            matlist_Q.append(matlist_flow_Q[ts]+matlist_proc_Q[ts])
-	
+
     # construct proper diagonals
     for ts in arange(0,len(matlist)):
         # seperate matrices from their diagonals        

--- a/mkbigD.py
+++ b/mkbigD.py
@@ -30,12 +30,12 @@ import os
 def mkprocmat(m):
     ''' returns a list of sparse matrices, one for each timestep, that
     contain D-values for intra-cell processes'''  
-    for tp in m.Dproc.keys(): # check whether we have all compartments
+    for tp in list(m.Dproc.keys()): # check whether we have all compartments
         tp=(tp[0],tp[1])
         for c in tp:
-            if c not in m.compdict.keys():
-                print('''mkprocmat.py: Compartment %i not in compartment-list.
-                Aborting !''') % (c)
+            if c not in list(m.compdict.keys()):
+                print(('''mkprocmat.py: Compartment %i not in compartment-list.
+                Aborting !''') % (c))
                 sys.exit(1)
     # construct list of large sparse matrices
     matlist=[]
@@ -46,7 +46,7 @@ def mkprocmat(m):
     for t in arange(0,m.nots):
         matlist.append(sp.coo_matrix(matrix(zeros((m.matdim,m.matdim),
                                                   dtype=float32))))    #original: float64 
-    for [k,v] in m.Dproc.items():
+    for [k,v] in list(m.Dproc.items()):
         toidx=array([x*m.nocomp+k[1]-1 for x in range(0,m.nocells)])
         fromidx=array([x*m.nocomp+k[0]-1 for x in range(0,m.nocells)])
         ij=(toidx.astype(int),fromidx.astype(int))
@@ -64,15 +64,15 @@ def mkprocmatQ(m):
     
     pdict=copy.deepcopy(m.Dproc)  
     mixQ=copy.deepcopy(m.DmixQ)
-    for tp in pdict.keys(): # check whether we have all compartments
+    for tp in list(pdict.keys()): # check whether we have all compartments
         tp=(tp[0],tp[1])
         for c in tp:
-            if c not in m.compdict.keys():
-                print('''mkprocmat.py: Compartment %i not in compartment-list.
-                Aborting !''') % (c)
+            if c not in list(m.compdict.keys()):
+                print(('''mkprocmat.py: Compartment %i not in compartment-list.
+                Aborting !''') % (c))
                 sys.exit(1)
 
-    for [k,v] in pdict.items():
+    for [k,v] in list(pdict.items()):
         key=k[0]-1
         mstring = k[2]
         if re.search("mix", mstring): 
@@ -84,7 +84,7 @@ def mkprocmatQ(m):
     for t in arange(0,m.nots):
         matlist.append(sp.coo_matrix(matrix(zeros((m.matdim,m.matdim),
                                                   dtype=float32))))   #original: float64 
-    for [k,v] in pdict.items():
+    for [k,v] in list(pdict.items()):
         toidx=array([x*m.nocomp+k[1]-1 for x in range(0,m.nocells)])
         fromidx=array([x*m.nocomp+k[0]-1 for x in range(0,m.nocells)])
         ij=(toidx.astype(int),fromidx.astype(int))
@@ -102,16 +102,16 @@ def mkflowQ(m):
     
     fdict=copy.deepcopy(m.Dflow)
     Qdict=copy.deepcopy(m.DflowQ)      #04.10.2016   fy
-    for tp in fdict.keys(): # check whether we have all compartments
+    for tp in list(fdict.keys()): # check whether we have all compartments
         for c in tp:
-            if c not in m.compdict.keys():
-                print('''flows.py: Compartment %i not in compartment-list.
-                Aborting !''') % (c)
+            if c not in list(m.compdict.keys()):
+                print(('''flows.py: Compartment %i not in compartment-list.
+                Aborting !''') % (c))
                 sys.exit(1)
     # remove intra-cell flows
     # this is for example oceanic sinking flux, which is dealt with
     # by "betr_ocean_sinkflux" in "processes.py".
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         intercell=list(where(v[:,0]!=v[:,1])[0])
         intracell=list(where(v[:,0]==v[:,1])[0])
         fdict[k]=v[intercell,:]
@@ -132,9 +132,9 @@ def mkflowQ(m):
         col1.append(x)
         col2.append(y)
     
-    for [kk,vv] in fdict.items():
+    for [kk,vv] in list(fdict.items()):
         if len(vv)==0: continue
-        for [k,v] in Qdict.items():
+        for [k,v] in list(Qdict.items()):
             if (kk[0]-1)==k:
                nv=zeros((len(v),14))           
                for ii in range(len(v)):
@@ -188,16 +188,16 @@ def mkflowmat(m):
     '''takes a model object (m) as argument and returns a list of sparse
     matrices which contain D-values from inter-cell flows for each timestep.'''
     fdict=copy.deepcopy(m.Dflow)
-    for tp in fdict.keys(): # check whether we have all compartments
+    for tp in list(fdict.keys()): # check whether we have all compartments
         for c in tp:
-            if c not in m.compdict.keys():
-                print('''flows.py: Compartment %i not in compartment-list.
-                Aborting !''') % (c)
+            if c not in list(m.compdict.keys()):
+                print(('''flows.py: Compartment %i not in compartment-list.
+                Aborting !''') % (c))
                 sys.exit(1)
     # remove intra-cell flows
     # this is for example oceanic sinking flux, which is dealt with
     # by "betr_ocean_sinkflux" in "processes.py".
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         intercell=list(where(v[:,0]!=v[:,1])[0])
         intracell=list(where(v[:,0]==v[:,1])[0])
         fdict[k]=v[intercell,:]
@@ -206,7 +206,7 @@ def mkflowmat(m):
     for t in arange(0,m.nots):
         matlist.append(sp.coo_matrix(matrix(zeros((m.matdim,m.matdim),
                                                   dtype=float32))))  # original: float64 
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         if len(v)==0: continue        
         toidx=array([(x-1)*m.nocomp+k[1]-1 for x in v[:,1]])
         fromidx=array([(x-1)*m.nocomp+k[0]-1 for x in v[:,0]])
@@ -222,16 +222,16 @@ def mkflowmatQ(m):
     '''Return a list of sparse
     matrices which contain D-values with Q from inter-cell flows for each timestep.'''
     fdict=mkflowQ(m)
-    for tp in fdict.keys(): # check whether we have all compartments
+    for tp in list(fdict.keys()): # check whether we have all compartments
         for c in tp:
-            if c not in m.compdict.keys():
-                print('''flows.py: Compartment %i not in compartment-list.
-                Aborting !''') % (c)
+            if c not in list(m.compdict.keys()):
+                print(('''flows.py: Compartment %i not in compartment-list.
+                Aborting !''') % (c))
                 sys.exit(1)
     # remove intra-cell flows
     # this is for example oceanic sinking flux, which is dealt with
     # by "betr_ocean_sinkflux" in "processes.py".
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         intercell=list(where(v[:,0]!=v[:,1])[0])
         intracell=list(where(v[:,0]==v[:,1])[0])
         fdict[k]=v[intercell,:]
@@ -241,7 +241,7 @@ def mkflowmatQ(m):
     for t in arange(0,m.nots):
         matlist.append(sp.coo_matrix(matrix(zeros((m.matdim,m.matdim),
                                                   dtype=float32))))  # original: float64 
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         if len(v)==0: continue
         toidx=array([(x-1)*m.nocomp+k[1]-1 for x in v[:,1]])
         fromidx=array([(x-1)*m.nocomp+k[0]-1 for x in v[:,0]])
@@ -321,7 +321,7 @@ def mkZVinv(m):
     # construct list of large sparse matrices
     mlist=[]
     diags=zeros((m.nots,m.matdim))
-    for c in m.compdict.keys():
+    for c in list(m.compdict.keys()):
         idx=tocell(arange(1, m.nocells+1),c,m)
         d=m.zdict[c]['bulk']*m.vdict[c]['bulk']    
         for t in arange(0,m.nots):

--- a/mkflowD.py
+++ b/mkflowD.py
@@ -17,18 +17,22 @@ def mkflowD(model):
     fdict=copy.deepcopy(model.flowdict)
     #If velocity of wind G/A is smaller than 1000m/h, the G/A should be 1000m/h. here, we consider
     #upper and lower air.   by FY
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         if k[0]==1 and k[1]==1:
             for i in range (len(v)):
                 for j in range(12):
-                    a=v[i][0]-1
+                    # newer numpy requires integers for indexing
+                    # v[i][0] is a float, so it must be cast
+                    a=int(v[i][0]-1)
                     velocity=v[i][j+2]/(sqrt(model.par['A'][a][j])*model.par['h1'][a][j])
                     if velocity<1000:
                        v[i][j+2]=1000*(sqrt(model.par['A'][a][j])*model.par['h1'][a][j])
         if k[0]==2 and k[1]==2:
             for i in range (len(v)):
                 for j in range(12):
-                    a=v[i][0]-1
+                    # newer numpy requires integers for indexing
+                    # v[i][0] is a float, so it must be cast
+                    a=int(v[i][0]-1)
                     velocity=v[i][j+2]/(sqrt(model.par['A'][a][j])*model.par['h2'][a][j])
                     if velocity<1000:
                        v[i][j+2]=1000*(sqrt(model.par['A'][a][j])*model.par['h2'][a][j])
@@ -36,7 +40,9 @@ def mkflowD(model):
         if k[0]==8 and k[1]==8:
             for i in range (len(v)):
                 for j in range(12):
-                    a=v[i][0]-1
+                    # newer numpy requires integers for indexing
+                    # v[i][0] is a float, so it must be cast
+                    a=int(v[i][0]-1)
                     velocity=v[i][j+2]/(sqrt(model.par['A'][a][j])*model.par['h1'][a][j])
                     if velocity<1000:
                        v[i][j+2]=1000*(sqrt(model.par['A'][a][j])*model.par['h1'][a][j])*model.par['fcp1'][a][j]
@@ -45,7 +51,9 @@ def mkflowD(model):
         if k[0]==9 and k[1]==9:        
             for i in range (len(v)):
                 for j in range(12):
-                    a=v[i][0]-1 
+                    # newer numpy requires integers for indexing
+                    # v[i][0] is a float, so it must be cast
+                    a=int(v[i][0]-1)
                     velocity=v[i][j+2]/(sqrt(model.par['A'][a][j])*model.par['h2'][a][j])                    
                     if velocity<1000:
                         v[i][j+2]=1000*(sqrt(model.par['A'][a][j])*model.par['h2'][a][j])*model.par['ffp2'][a][j]
@@ -60,7 +68,9 @@ def mkflowD(model):
         if k[0]==10 and k[1]==10:
             for i in range (len(v)):
                 for j in range(12):
-                    a=v[i][0]-1
+                    # newer numpy requires integers for indexing
+                    # v[i][0] is a float, so it must be cast
+                    a=int(v[i][0]-1)
                     velocity=v[i][j+2]/(sqrt(model.par['A'][a][j])*model.par['h2'][a][j])
                     if velocity<1000:
                        v[i][j+2]=1000*(sqrt(model.par['A'][a][j])*model.par['h2'][a][j])*model.par['fcp2'][a][j]
@@ -68,7 +78,7 @@ def mkflowD(model):
                        v[i][j+2]=v[i][j+2]*model.par['fcp2'][a][j]
 
     #Dflow=GZ
-    for f in fdict.keys():        
+    for f in list(fdict.keys()):        
         fromcells=fdict[f][:,0].astype(int)
         zvals=model.zdict[f[0]]['bulk'][fromcells-1,:]
         vvals=model.vdict[f[0]]['bulk'][fromcells-1,:]   #FY

--- a/mkflowDQ.py
+++ b/mkflowDQ.py
@@ -24,23 +24,23 @@ def mkflowDQ(m):       #Fy   15.08.2016
     Kloss=zeros((comp,cells,seasons))    #  Fy  20.09.2016
                
     ''' uses zdict and vdict to construct vz'''
-    for c in m.compdict.keys():
+    for c in list(m.compdict.keys()):
         vz[c-1]=m.zdict[c]['bulk']*m.vdict[c]['bulk']
         
     '''use Dflow and Dprocess to construct Dtotalloss'''
     '''Dflow'''
     fdict=copy.deepcopy(m.Dflow)
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         intercell=list(where(v[:,0]!=v[:,1])[0])
         intracell=list(where(v[:,0]==v[:,1])[0])
         fdict[k]=v[intercell,:]
         
     T=[]
     Q=[]
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         T.append([])
         Q.append([])
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         if k[0]==4 and k[1]==5: continue
         c=k[0]-1
         T[c]=zeros((len(v),len(v[0])))
@@ -55,7 +55,7 @@ def mkflowDQ(m):       #Fy   15.08.2016
                    T[c][i][(2+ii)]=vz[c][a][ii]/v[i][(2+ii)]
 
     '''Dprocess'''  
-    for [k,v] in m.Dproc.items():
+    for [k,v] in list(m.Dproc.items()):
         key=k[0]-1
         mstring = k[2]
         if re.search("deg|wet|disso", mstring): 
@@ -76,7 +76,7 @@ def mkflowDQ(m):       #Fy   15.08.2016
                 
    
     '''calcuate Q, here we only calculate upper air and lower air, Q1,Q2'''
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         c=k[0]-1
         for ii in range(len(T[c])):
             b=T[c][ii][0]-1
@@ -99,18 +99,18 @@ def mkDQnocells(m):       #Fy   15.08.2016
     Q=zeros((comp,cells,seasons))
                
     ''' uses zdict and vdict to construct vz'''
-    for c in m.compdict.keys():
+    for c in list(m.compdict.keys()):
         vz[c-1]=m.zdict[c]['bulk']*m.vdict[c]['bulk']
         
     '''use Dflow and Dprocess to construct Dtotalloss'''
     '''Dflow'''
     fdict=copy.deepcopy(m.Dflow)
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         intercell=list(where(v[:,0]!=v[:,1])[0])
         intracell=list(where(v[:,0]==v[:,1])[0])
         fdict[k]=v[intercell,:]
         
-    for [k,v] in fdict.items():
+    for [k,v] in list(fdict.items()):
         mdf=zeros((comp,len(v[:,0]),14))
         if k[0]==4 and k[1]==5: continue
         c=k[0]-1
@@ -130,7 +130,7 @@ def mkDQnocells(m):       #Fy   15.08.2016
 
 
     '''Dprocess'''
-    for [k,v] in m.Dproc.items():
+    for [k,v] in list(m.Dproc.items()):
         key=k[0]-1
         if key==0: dk[0]+=v
         if key==1: dk[1]+=v

--- a/output.py
+++ b/output.py
@@ -16,7 +16,7 @@ import pdb
 #try:
 from write_ncfile import *
 #except ImportError:
-#	from write_ncfile_old import *
+#   from write_ncfile_old import *
 
 from helpers import *
 from helpers3 import *
@@ -151,7 +151,7 @@ def write_output_dyn(m, fn, units, netcdf, cpk):     # parameter cpk added by HW
             out[c]['mol_per_m3']=m.dyn_res[idx]/varr
             out[c]['mol_per_m3'][zerovolidx]=0
         if 'kg_per_m3' in units:
-	    out[c]['kg_per_m3']=m.dyn_res[idx]*m.chemdict['molmass']/1000.0/varr
+            out[c]['kg_per_m3']=m.dyn_res[idx]*m.chemdict['molmass']/1000.0/varr
             out[c]['kg_per_m3'][zerovolidx]=0
         if  'ng_per_m3' in units:            
             out[c]['ng_per_m3']=m.dyn_res[idx]*m.chemdict['molmass']*1e9/varr  

--- a/output.py
+++ b/output.py
@@ -9,7 +9,7 @@ from numpy import *
 import sys
 import os
 import csv
-import cPickle
+import pickle
 import pdb
 #import write_ncfile
 #reload(write_ncfile)
@@ -29,9 +29,9 @@ def write_cpk_file(fn, out):
         os.mkdir(os.path.dirname(fncpk))
     else:
         if os.path.exists(fncpk):
-            print('Attention: overwriting %s\n') % (fncpk)
+            print(('Attention: overwriting %s\n') % (fncpk))
     f=open(fncpk,'w')
-    cPickle.dump(out,f)
+    pickle.dump(out,f)
     f.close()
 
 def write_output_summary(m, fn, nchemical, nrun, nchemdb, nseasonalparfile, nconstantparfile,\
@@ -63,9 +63,9 @@ def write_output_ss(m, fn, units, netcdf, cpk):     # parameter cpk added by HW
     nlat=int(sqrt(m.matdim/m.nocomp/2))                  # added by HW
     nlon=int(sqrt(m.matdim/m.nocomp/2)*2)                # added by HW
     out={}
-    for c in m.compdict.keys():
+    for c in list(m.compdict.keys()):
         out[c]={}
-        idx=arange(c-1,m.matdim,len(m.compdict.keys()))
+        idx=arange(c-1,m.matdim,len(list(m.compdict.keys())))
         ## deal with zero-volumes / Z-values
         varr=mean(m.vdict[c]['bulk'],axis=1)
         zv_arr=mean(m.zdict[c]['bulk'],axis=1)*varr
@@ -102,18 +102,18 @@ def write_output_ss(m, fn, units, netcdf, cpk):     # parameter cpk added by HW
             #os.mkdir(os.path.dirname(fncpk))
         #else:
         if os.path.exists(fncpk):
-            print('Attention: overwriting %s\n') % (fncpk)
-        f=open(fncpk,'w')
-        cPickle.dump(out,f)
+            print(('Attention: overwriting %s\n') % (fncpk))
+        f=open(fncpk,'wb')
+        pickle.dump(out,f)
         f.close()
     if netcdf:
         for u in units:
             fnnc=fn+'_'+u+'.nc'
             if os.path.exists(fnnc):
-                print('Attention: overwriting %s\n') % (fnnc)
+                print(('Attention: overwriting %s\n') % (fnnc))
             #outarray=zeros((m.nocomp,nlon,nlat)) #12,24
             outarray=zeros((m.nocomp,nlat,nlon)) #12,24 # Modified by RKG, 28.07.2014
-            for c in m.compdict.keys():
+            for c in list(m.compdict.keys()):
                 #outarray[c-1,:,:]=out[c][u].reshape(nlon,nlat) #12,24
                 outarray[c-1,:,:]=out[c][u].reshape(nlat,nlon) #12,24 # Modified by RKG, 28.07.2014
             writenc(outarray,fnnc,False,True,1,varname='V',unit=u)
@@ -130,9 +130,9 @@ def write_output_dyn(m, fn, units, netcdf, cpk):     # parameter cpk added by HW
     if periods != (timesteps-1)/float(m.nots):
         sys.exit('timesteps of output {0:d} not multiple of '
                  +'seasons ({1:d}): Aborting !'.format(timesteps,m.nots))
-    for c in m.compdict.keys():
+    for c in list(m.compdict.keys()):
         out[c]={}
-        idx=arange(c-1,m.matdim,len(m.compdict.keys()))
+        idx=arange(c-1,m.matdim,len(list(m.compdict.keys())))
         ## deal with zero volumes / Z-values
         varr=hstack((ones((idx.shape[0],1)),
                      tile(m.vdict[c]['bulk'], (1,periods))))
@@ -172,17 +172,17 @@ def write_output_dyn(m, fn, units, netcdf, cpk):     # parameter cpk added by HW
             #os.mkdir(os.path.dirname(fncpk))
         #else:
         if os.path.exists(fncpk):
-            print('Attention: overwriting %s\n') % (fncpk)
-        f=open(fncpk,'w')
-        cPickle.dump(out,f)
+            print(('Attention: overwriting %s\n') % (fncpk))
+        f=open(fncpk,'wb')
+        pickle.dump(out,f)
         f.close()
     if netcdf:
         for u in units:
             fnnc=fn+'_'+u+'.nc'
             if os.path.exists(fnnc):
-                print('Attention: overwriting %s\n') % (fnnc)
+                print(('Attention: overwriting %s\n') % (fnnc))
             outarray=zeros((timesteps,m.nocomp,nlat,nlon))# 12,24
-            for c in m.compdict.keys():
+            for c in list(m.compdict.keys()):
                 for t in arange(0,timesteps):
                     outarray[t,c-1,:,:]=out[c][u][:,t].reshape(nlat,nlon) #12,24
             writenc(outarray, fnnc, True, True, 1, varname='V',unit=u)
@@ -210,9 +210,9 @@ def write_output_se(m, fn, units, netcdf, cpk, scenario="air"):     # parameter 
     if periods != (timesteps-1)/float(m.nots):
         sys.exit('timesteps of output {0:d} not multiple of '
                  +'seasons ({1:d}): Aborting !'.format(timesteps,m.nots))
-    for c in m.compdict.keys():
+    for c in list(m.compdict.keys()):
         out[c]={}
-        idx=arange(c-1,m.matdim,len(m.compdict.keys()))
+        idx=arange(c-1,m.matdim,len(list(m.compdict.keys())))
         ## deal with zero volumes / Z-values
         varr=hstack((ones((idx.shape[0],1)),
                      tile(m.vdict[c]['bulk'], (1,periods))))
@@ -240,27 +240,29 @@ def write_output_se(m, fn, units, netcdf, cpk, scenario="air"):     # parameter 
             #os.mkdir(os.path.dirname(fncpk))
         #else:
         if os.path.exists(fncpk):
-            print('Attention: overwriting %s\n') % (fncpk)
+            print(('Attention: overwriting %s\n') % (fncpk))
         f=open(fncpk,'w')
-        cPickle.dump(out,f)
+        pickle.dump(out,f)
         f.close()
     if netcdf:
         for u in units:
             fnnc=fn+'_'+u+'.nc'
             if os.path.exists(fnnc):
-                print('Attention: overwriting %s\n') % (fnnc)
+                print(('Attention: overwriting %s\n') % (fnnc))
             outarray=zeros((timesteps,m.nocomp,nlat,nlon))# 12,24
-            for c in m.compdict.keys():
+            for c in list(m.compdict.keys()):
                 for t in arange(0,timesteps):
                     outarray[t,c-1,:,:]=out[c][u][:,t].reshape(nlat,nlon) #12,24
             writenc(outarray, fnnc, True, True, 1, varname='V',unit=u)
             
             
 def write_output_dyn_tmp(m, fn, timesteps):                             # function added by HW
-    nreg=m.matdim/m.nocomp    
+    # Newer versions of numpy cannot use floats for shapes
+    # the division here creates a float
+    nreg=int(m.matdim/m.nocomp)
     out_tmp = zeros([nreg*m.nocomp, 3])#288*7
-    out_tmp[:, 0] = tile(range(1, nreg+1), m.nocomp)#289
-    out_tmp[:, 1] = repeat(range(1, m.nocomp+1), nreg)#288
+    out_tmp[:, 0] = tile(list(range(1, nreg+1)), m.nocomp)#289
+    out_tmp[:, 1] = repeat(list(range(1, m.nocomp+1)), nreg)#288
     
     #timesteps=m.dyn_res.shape[1]
     periods=int((timesteps-1)/float(m.nots))
@@ -268,8 +270,8 @@ def write_output_dyn_tmp(m, fn, timesteps):                             # functi
         sys.exit('timesteps of output {0:d} not multiple of '
                  +'seasons ({1:d}): Aborting !'.format(timesteps,m.nots))
     
-    for c in m.compdict.keys():
-        idx=arange(c-1,m.matdim,len(m.compdict.keys()))
+    for c in list(m.compdict.keys()):
+        idx=arange(c-1,m.matdim,len(list(m.compdict.keys())))
         ## deal with zero volumes / Z-values
         varr=hstack((ones((idx.shape[0],1)),
                      tile(m.vdict[c]['bulk'], (1,periods))))
@@ -286,10 +288,12 @@ def write_output_dyn_tmp(m, fn, timesteps):                             # functi
     
     
 def write_output_end_txt(m, fn, timesteps):                             # function added by HW
-    nreg=m.matdim/m.nocomp
+    # Newer versions of numpy cannot use floats for shapes
+    # the division here creates a float
+    nreg=int(m.matdim/m.nocomp)
     out_tmp = zeros([nreg*m.nocomp, 3])#288*7
-    out_tmp[:, 0] = tile(range(1, nreg+1), m.nocomp)#289
-    out_tmp[:, 1] = repeat(range(1, m.nocomp+1), nreg)#288
+    out_tmp[:, 0] = tile(list(range(1, nreg+1)), m.nocomp)#289
+    out_tmp[:, 1] = repeat(list(range(1, m.nocomp+1)), nreg)#288
     
     #timesteps = m.dyn_res.shape[1]    
     periods=int((timesteps-1)/float(m.nots))
@@ -297,8 +301,8 @@ def write_output_end_txt(m, fn, timesteps):                             # functi
         sys.exit('timesteps of output {0:d} not multiple of '
                  +'seasons ({1:d}): Aborting !'.format(timesteps,m.nots))
     
-    for c in m.compdict.keys():
-        idx=arange(c-1,m.matdim,len(m.compdict.keys()))
+    for c in list(m.compdict.keys()):
+        idx=arange(c-1,m.matdim,len(list(m.compdict.keys())))
         ## deal with zero volumes / Z-values
         varr=hstack((ones((idx.shape[0],1)),
                      tile(m.vdict[c]['bulk'], (1,periods))))
@@ -314,10 +318,12 @@ def write_output_end_txt(m, fn, timesteps):                             # functi
     savetxt(fn, out_tmp, fmt = ['%i', '%i', '%.16e'], delimiter=' ')   # changed from .8e to .16e
 
 def write_output_ss_txt(m, fn):                             # function added by RKG, 04.01.2014
-    nreg=m.matdim/m.nocomp
+    # Newer versions of numpy cannot use floats for shapes
+    # the division here creates a float
+    nreg=int(m.matdim/m.nocomp)
     out_tmp = zeros([nreg*m.nocomp, 3])#288*7
-    out_tmp[:, 0] = tile(range(1, nreg+1), m.nocomp)#289
-    out_tmp[:, 1] = repeat(range(1, m.nocomp+1), nreg)#288
+    out_tmp[:, 0] = tile(list(range(1, nreg+1)), m.nocomp)#289
+    out_tmp[:, 1] = repeat(list(range(1, m.nocomp+1)), nreg)#288
     
     #timesteps = m.dyn_res.shape[1]    
     #periods=int((timesteps-1)/float(m.nots))
@@ -325,8 +331,8 @@ def write_output_ss_txt(m, fn):                             # function added by 
     #    sys.exit('timesteps of output {0:d} not multiple of '
     #             +'seasons ({1:d}): Aborting !'.format(timesteps,m.nots))
     
-    for c in m.compdict.keys():
-        idx=arange(c-1,m.matdim,len(m.compdict.keys()))
+    for c in list(m.compdict.keys()):
+        idx=arange(c-1,m.matdim,len(list(m.compdict.keys())))
         ## deal with zero volumes / Z-values
     #    varr=hstack((ones((idx.shape[0],1)),
     #                 tile(m.vdict[c]['bulk'], (1,periods))))
@@ -343,40 +349,42 @@ def write_output_ss_txt(m, fn):                             # function added by 
 
     
 def write_bigDlist_txt(bigDlist, fn2, fn3,fn4, fn5,m):             # function added by HW, and modified by FY
-    nreg=m.matdim/m.nocomp
+    # Newer versions of numpy cannot use floats for shapes
+    # the division here creates a float
+    nreg=int(m.matdim/m.nocomp)
     #dtypeDlist = [('regfrom', int), ('compfrom', int), ('regto', int), ('compto', int), 
                       #(str(1), float), (str(2), float), (str(3), float), (str(4), float), (str(5), float), (str(6), float),
                       #(str(7), float), (str(8), float), (str(9), float), (str(10), float), (str(11), float), (str(12), float)]
     Dflow = zeros((7*nreg*nreg, 16))   #7 means numbers of compartments, see the line starting with Dflow[:,range(0,4)] 
-    fromreg = hstack([sort(range(1,nreg+1)*nreg)]*7)
-    toreg = hstack([range(1,nreg+1)*nreg]*7)
-    Dflow[:,range(0,4)] = transpose([fromreg,
+    fromreg = hstack([sort(list(range(1,nreg+1))*nreg)]*7)
+    toreg = hstack([list(range(1,nreg+1))*nreg]*7)
+    Dflow[:,list(range(0,4))] = transpose([fromreg,
                                      hstack([[1]*nreg*nreg, [2]*nreg*nreg, [4]*nreg*nreg, [5]*nreg*nreg, [7]*nreg*nreg, [8]*nreg*nreg, [9]*nreg*nreg]),
                                      toreg,
                                      hstack([[1]*nreg*nreg, [2]*nreg*nreg, [4]*nreg*nreg, [5]*nreg*nreg, [7]*nreg*nreg, [8]*nreg*nreg, [9]*nreg*nreg])])
     Dflow = Dflow[Dflow[:,0] != Dflow[:,2], :]
     for month in range(0,12):
         Dflow[:,month + 4] = bigDlist[month][tocell(Dflow[:,2], Dflow[:,3], m), tocell(Dflow[:,0], Dflow[:,1], m)]
-    Dflow = Dflow[findnonemptycells(Dflow[:, range(4,16)]), :]
+    Dflow = Dflow[findnonemptycells(Dflow[:, list(range(4,16))]), :]
     
     Ddiag = zeros((m.nocomp*nreg, 16))
-    fromreg = sort(range(1,nreg+1)*m.nocomp)
-    fromcomp = range(1,m.nocomp+1)*nreg
-    Ddiag[:,range(0,4)] = transpose([fromreg, fromcomp, fromreg, fromcomp])
+    fromreg = sort(list(range(1,nreg+1))*m.nocomp)
+    fromcomp = list(range(1,m.nocomp+1))*nreg
+    Ddiag[:,list(range(0,4))] = transpose([fromreg, fromcomp, fromreg, fromcomp])
     for month in range(0,12):
         Ddiag[:,month + 4] = bigDlist[month][tocell(Ddiag[:,2], Ddiag[:,3], m), tocell(Ddiag[:,0], Ddiag[:,1], m)]
-    Ddiag = Ddiag[findnonemptycells(Ddiag[:, range(4,16)]), :]
+    Ddiag = Ddiag[findnonemptycells(Ddiag[:, list(range(4,16))]), :]
     
     Dint = zeros((nreg*m.nocomp*m.nocomp, 16))
-    fromreg = sort(range(1,nreg+1)*m.nocomp*m.nocomp)
-    fromcomp = hstack([sort(range(1,m.nocomp+1)*m.nocomp)]*nreg)
-    tocomp = range(1,m.nocomp+1)*m.nocomp*nreg
-    Dint[:,range(0,4)] = transpose([fromreg, fromcomp, fromreg, tocomp])
+    fromreg = sort(list(range(1,nreg+1))*m.nocomp*m.nocomp)
+    fromcomp = hstack([sort(list(range(1,m.nocomp+1))*m.nocomp)]*nreg)
+    tocomp = list(range(1,m.nocomp+1))*m.nocomp*nreg
+    Dint[:,list(range(0,4))] = transpose([fromreg, fromcomp, fromreg, tocomp])
     Dint = Dint[Dint[:,1] != Dint[:,3],:]
     Dint = Dint[Dint[:,0] == Dint[:,2],:]   # unneccesary
     for month in range(0,12):
         Dint[:,month + 4] = bigDlist[month][tocell(Dint[:,2], Dint[:,3], m), tocell(Dint[:,0], Dint[:,1], m)]
-    Dint = Dint[findnonemptycells(Dint[:, range(4,16)]), :]
+    Dint = Dint[findnonemptycells(Dint[:, list(range(4,16))]), :]
     
     bigDlist2 = vstack([Dflow, Ddiag, Dint])
     '''
@@ -435,14 +443,14 @@ def write_output_dflux(m,fn,netcdf=False,units=['mol'],nlat=12,nlon=24):
 #    possiblefiles = ["flow", "airwater", "deg", "sed", "dep_air", "dep_water"]
     
     out = mk_allfluxes(m)
-    k = out.keys()[0]
+    k = list(out.keys())[0]
     timesteps=len(out[k])
     write_cpk_file(fn, out)
     if netcdf:
-        for u in out.keys():
+        for u in list(out.keys()):
             fnnc=fn+'_'+u+'.nc'
             if os.path.exists(fnnc):
-                print('Attention: overwriting %s\n') % (fnnc)
+                print(('Attention: overwriting %s\n') % (fnnc))
             outarray=zeros((timesteps,1,nlat,nlon))
             for t in arange(0,timesteps):
                     outarray[t,0,:,:]=out[u][t].reshape(nlat,nlon)
@@ -489,7 +497,7 @@ def mk_allfluxes(m, nseasons=12):
         season = ts % nseasons
         year = ts / nseasons
         if season ==0:
-            print ("Processing year %i \t" %(year)),
+            print(("Processing year %i \t" %(year)), end=' ')
         
         fluxmat = m.flux_res[ts]
         x,y = fluxmat.nonzero()
@@ -505,8 +513,8 @@ def mk_allfluxes(m, nseasons=12):
                     match_dict = m.flux_key[season][xcell][xcomp]
                     #print 'match_dict', match_dict
                 except KeyError:
-                    print [[season],[xcell],[xcomp]]
-                for mnkey in match_dict.keys():
+                    print([[season],[xcell],[xcomp]])
+                for mnkey in list(match_dict.keys()):
                     
                     if type(mnkey) is tuple:                             
                         if xcomp in [0]:
@@ -615,11 +623,11 @@ def mk_allfluxes(m, nseasons=12):
                                           /(fluxdict["flow_out_lower_caerosol"][ts][i]+fluxdict["lower_caerosol_to_all"][ts][i]\
                                             +fluxdict["lower_caerosol_sed"][ts][i]+fluxdict["lower_caerosol_deg"][ts][i])
                     
-        print ("."),
+        print(("."), end=' ')
         if season == (nseasons-1):
-            print('  [%.3f s]')  % (time.time()-ts1)
+            print(('  [%.3f s]')  % (time.time()-ts1))
             ts1=time.time()        
-    print ("Time in mk_allfluxes(): %.3f min " % ((time.time()-ts0)/60.))
+    print(("Time in mk_allfluxes(): %.3f min " % ((time.time()-ts0)/60.)))
     return fluxdict        
                       
                           

--- a/readinput.py
+++ b/readinput.py
@@ -7,7 +7,6 @@ This module reads and batters into shape the input parameters'''
 ################################################################################
 from numpy import *
 import os
-import string
 import inspect
 import glob
 import csv
@@ -33,7 +32,7 @@ def _readEnvironment(partype, fn):
         line_old=line
         line=f.readline()
         c=line[0]
-    header=string.split(line_old)
+    header=str.split(line_old)
     header[0]=header[0].lstrip("#")
     f.close()
     if partype == 'const':    
@@ -59,7 +58,7 @@ def _readEnvironment(partype, fn):
         ## 1) increasing cell number and 2) increasing timestep
         pars=sort(pars, axis=0, order=['CELL','TS'])
         fields=list(pars.dtype.names)
-        fields=filter(lambda x: x!='CELL' and x!='TS', fields)
+        fields=[x for x in fields if x!='CELL' and x!='TS']
         pars=pars[fields]
         pars=reshape(pars,(cells, ts))
     return(pars)
@@ -96,17 +95,17 @@ def readCompartments(fn):
         line=f.readline()
         if line[0] == "#":
             continue
-        header=string.split(line)
+        header=str.split(line)
         del(header[0])
         break
     while True:
         line=f.readline()
         if line == '': break
         if line[0] =='#' or line == '\n': continue
-        line=string.split(line)
+        line=str.split(line)
         num=line[0]
         del line[0]
-        compdict[int(num)] = dict(zip(header,line))
+        compdict[int(num)] = dict(list(zip(header,line)))
     return(compdict)
 
 def readFlows(complist, flowdir):
@@ -155,7 +154,7 @@ def readChemicals(chemlist, fn):
         line=f.readline()
         c=line[0]
         count+=1
-    header=string.split(line_old)
+    header=str.split(line_old)
     header[0]=header[0].lstrip("#")
     f.seek(0)
     # jump over comments
@@ -185,7 +184,7 @@ def readProcesses(compdict, fn):
         if line[0] == '#' or line == '\n': continue
         line=line.split()
         comps=[int(x) for x in line[1:]]
-        if all([x in compdict.keys() for x in comps]):
+        if all([x in list(compdict.keys()) for x in comps]):
             pl=[line[0]]
             pl.extend(comps)
             proclist.append(tuple(pl))

--- a/runBDE209_dyn_br.py
+++ b/runBDE209_dyn_br.py
@@ -2,7 +2,8 @@
 import os
 import time
 import BETRS
-reload(BETRS)
+import importlib
+importlib.reload(BETRS)
 from BETRS import *
 import pdb
 
@@ -31,7 +32,7 @@ dname = os.path.dirname(abspath)
 os.chdir(dname)
 
 runID = ['BDE209_dyn_br'] # output names 
-years = [range(1970,2051)]*len(runID)    # range of modeling run (years)
+years = [list(range(1970,2051))]*len(runID)    # range of modeling run (years)
 
 emisdir = ['Emission_BDE209_10_comparts']  # emission inventory ('Emissions/annual/')
 #emisfile = ['emissions_dyn_GenNL_br.txt']*len(runID) # emission inventory ('Emissions/')
@@ -57,9 +58,9 @@ for v in [years, emisdir, seasparfile, chemdata, chemnr, constparfile, compfile,
 ## now run the model
 
 for i in range(0, len(runID)):
-    print('\n\nStarting run ' + runID[i])
+    print(('\n\nStarting run ' + runID[i]))
     ## model first year and write temporary result to text file
-    print('\n\nBETR run ' + runID[i] + ' for year ' + str(years[i][0]))
+    print(('\n\nBETR run ' + runID[i] + ' for year ' + str(years[i][0])))
     m=Model(chemical = chemnr[i],
             run = runID[i],
             chemdb = chemdata[i],
@@ -89,7 +90,7 @@ for i in range(0, len(runID)):
     ## model year 2 to n
     for y in years[i][1:]:
         del(m)
-        print('\n\nBETR run ' + runID[i] + ' for year ' + str(y))
+        print(('\n\nBETR run ' + runID[i] + ' for year ' + str(y)))
         m=Model(chemical = chemnr[i], 
             run = runID[i],
             chemdb = chemdata[i],
@@ -130,6 +131,6 @@ for i in range(0, len(runID)):
 
     t_e = time.time() # End time
 
-    print 'Simulation completed!'
-    print runID
-    print 'TOTAL SIMULATION TIME: %f minutes = %f hours.' % ( (t_e - t_s) / 60.0 , (t_e - t_s) / 3600.0 )
+    print('Simulation completed!')
+    print(runID)
+    print('TOTAL SIMULATION TIME: %f minutes = %f hours.' % ( (t_e - t_s) / 60.0 , (t_e - t_s) / 3600.0 ))

--- a/runTCPP_dyn_br.py
+++ b/runTCPP_dyn_br.py
@@ -2,7 +2,8 @@
 import os
 import time
 import BETRS
-reload(BETRS)
+import importlib
+importlib.reload(BETRS)
 from BETRS import *
 import pdb
 
@@ -31,7 +32,7 @@ dname = os.path.dirname(abspath)
 os.chdir(dname)
 
 runID = ['TCPP_dyn_br'] # output names 
-years = [range(1)]*len(runID)    # range of modeling run (years)
+years = [list(range(1))]*len(runID)    # range of modeling run (years)
 
 #emisdir = ['PCB28_HIGH_0375_mol_per_hour']  # emission inventory ('Emissions/annual/')
 emisfile = ['Emission_TCPP_10_comparts.txt']*len(runID) # emission inventory ('Emissions/')
@@ -57,9 +58,9 @@ for v in [emisfile, seasparfile, chemdata, chemnr, constparfile, compfile, flowd
 ## now run the model
 
 for i in range(0, len(runID)):
-    print('\n\nStarting run ' + runID[i])
+    print(('\n\nStarting run ' + runID[i]))
     ## model first year and write temporary result to text file
-    print('\n\nBETR run ' + runID[i] + ' for year ' + str(years[i][0]))
+    print(('\n\nBETR run ' + runID[i] + ' for year ' + str(years[i][0])))
     m=Model(chemical = chemnr[i],
             run = runID[i],
             chemdb = chemdata[i],
@@ -87,7 +88,7 @@ for i in range(0, len(runID)):
     ## model year 2 to n
     for y in years[i][1:]:
         del(m)
-        print('\n\nBETR run ' + runID[i] + ' for year ' + str(y))
+        print(('\n\nBETR run ' + runID[i] + ' for year ' + str(y)))
         m=Model(chemical = chemnr[i], 
             run = runID[i],
             chemdb = chemdata[i],
@@ -128,6 +129,6 @@ for i in range(0, len(runID)):
 
     t_e = time.time() # End time
 
-    print 'Simulation completed!'
-    print runID
-    print 'TOTAL SIMULATION TIME: %f minutes = %f hours.' % ( (t_e - t_s) / 60.0 , (t_e - t_s) / 3600.0 )
+    print('Simulation completed!')
+    print(runID)
+    print('TOTAL SIMULATION TIME: %f minutes = %f hours.' % ( (t_e - t_s) / 60.0 , (t_e - t_s) / 3600.0 ))

--- a/runTCPP_ss_br.py
+++ b/runTCPP_ss_br.py
@@ -2,7 +2,8 @@
 import os
 import time
 import BETRS
-reload(BETRS)
+import importlib
+importlib.reload(BETRS)
 from BETRS import *
 import pdb
 
@@ -31,7 +32,7 @@ dname = os.path.dirname(abspath)
 os.chdir(dname)
 
 runID = ['TCPP_ss_br'] # output names 
-years = [range(1)]*len(runID)    # range of modeling run (years)
+years = [list(range(1))]*len(runID)    # range of modeling run (years)
 
 #emisdir = ['Emission_BDE209_10_comparts']  # emission inventory ('Emissions/annual/')
 emisfile = ['Emission_TCPP_10_comparts.txt']*len(runID) # emission inventory ('Emissions/')
@@ -57,9 +58,9 @@ for v in [emisfile, seasparfile, chemdata, chemnr, constparfile, compfile, flowd
 ## now run the model
 
 for i in range(0, len(runID)):
-    print('\n\nStarting run ' + runID[i])
+    print(('\n\nStarting run ' + runID[i]))
     ## model first year and write temporary result to text file
-    print('\n\nBETR run ' + runID[i] + ' for year ' + str(years[i][0]))
+    print(('\n\nBETR run ' + runID[i] + ' for year ' + str(years[i][0])))
     m=Model(chemical = chemnr[i],
             run = runID[i],
             chemdb = chemdata[i],
@@ -91,7 +92,7 @@ for i in range(0, len(runID)):
 
     t_e = time.time() # End time
 
-    print 'Simulation completed!'
-    print 'TOTAL SIMULATION TIME: %f minutes' % ((t_e - t_s) / 60.0)
+    print('Simulation completed!')
+    print('TOTAL SIMULATION TIME: %f minutes' % ((t_e - t_s) / 60.0))
 
     

--- a/secondary_emission_reconstruction.py
+++ b/secondary_emission_reconstruction.py
@@ -94,9 +94,9 @@ def reconstruct_dyn_res(m, scenario="air",nseasons=12):
         x,y = fluxmat.nonzero()
         
         if season ==0:
-            print ("\nProcessing year %i \t" %(year)),
+            print(("\nProcessing year %i \t" %(year)), end=' ')
         
-        print ".",
+        print(".", end=' ')
         
         ''' For loop through compartment and treat in fluxes first '''
         for i in range(len(x)):
@@ -113,11 +113,11 @@ def reconstruct_dyn_res(m, scenario="air",nseasons=12):
                 try :
                     match_dict = m.flux_key[season][xcell][xcomp]
                 except KeyError:
-                    print [[season],[xcell],[xcomp]]
+                    print([[season],[xcell],[xcomp]])
                 
                 minus_mass[ind_from] -= value
                 
-                for mnkey in match_dict.keys():
+                for mnkey in list(match_dict.keys()):
                      
                     '''Flow to and from neighboring cells'''
                     if type(mnkey) is tuple:
@@ -135,7 +135,7 @@ def reconstruct_dyn_res(m, scenario="air",nseasons=12):
                                 value * \
                                 (org_frac_se[ind_from])
                         except IndexError:
-                            print mnkey[1], (mnkey[1]-1)*m.nocomp+xcomp, ind_from
+                            print(mnkey[1], (mnkey[1]-1)*m.nocomp+xcomp, ind_from)
                             raise IndexError
 #                    if mnkey  == "deg":
 #                        minus_mass[ind_from] -= flux_key[season][xcell][xcomp][mnkey] * value

--- a/solver.py
+++ b/solver.py
@@ -129,7 +129,7 @@ class Solver:
         ts0=time.time()
         
         for m in range(0, ts):
-            print('Integrating month # %s') % (m)
+            print(('Integrating month # %s') % (m))
             #ig.set_initial_value(ig.y, ig.t)
             
             current_season = mod(m, self.steps_per_period)
@@ -159,8 +159,8 @@ class Solver:
                 Diff_upper = (dot(self.model.bigDlist[current_season],
                                                     diags(self.y0, 0))
                                                     * substeplength)
-                print('\tSeason %d\t %d substeps of length %.5f hours')\
-                            % (current_season,no_sub_steps, substeplength)
+                print(('\tSeason %d\t %d substeps of length %.5f hours')\
+                            % (current_season,no_sub_steps, substeplength))
                                    
             elif with_deriv and exp_t_steps:
                 substeplist= (10.**(1./10.))**arange(1,11)
@@ -172,22 +172,22 @@ class Solver:
                                                     diags(self.y0, 0))
                                                     * substeplist[0])
                 no_sub_steps=len(substeplist)                                                   
-                print('\tSeason %d\t %d substeps of length %.5f to %.5f hours')\
+                print(('\tSeason %d\t %d substeps of length %.5f to %.5f hours')\
                             % (
                                current_season,
                                no_sub_steps,
                                substeplist[0],
                                substeplist[-1],
-                               )                                                    
+                               ))                                                    
                 
             else:    
                 substeplength = self.stepdef[current_season] / no_sub_steps
 
-                print('\tSeason %d\t %d substeps of length %.5f hours')\
-                            % (current_season,no_sub_steps, substeplength)
+                print(('\tSeason %d\t %d substeps of length %.5f hours')\
+                            % (current_season,no_sub_steps, substeplength))
             te1=time.time()
             ts1=time.time()
-            print('\tIntegrating %i substeps: ' % no_sub_steps),
+            print(('\tIntegrating %i substeps: ' % no_sub_steps), end=' ')
             for i in range(0, no_sub_steps):
 
                 ig.integrate(ig.t + substeplength)
@@ -221,9 +221,9 @@ class Solver:
                     sys.exit("Integration failed; aborting !")
                 te1=time.time()
                 if no_sub_steps > 1:
-                    if i % (no_sub_steps/20) == 0: print('.'),
+                    if i % (no_sub_steps/20) == 0: print(('.'), end=' ')
             
-            print('\n done with month %d  [%.3f s]')  % (m, (te1-ts1))
+            print(('\n done with month %d  [%.3f s]')  % (m, (te1-ts1)))
             
             
             if track_flow:
@@ -256,7 +256,7 @@ class Solver:
                 res=vstack((res, ig.y))
             """Stop timer"""
             te0=time.time()
-        print "time elapsed: %f minutes" % ((te0-ts0)/60.0)
+        print("time elapsed: %f minutes" % ((te0-ts0)/60.0))
         res=res.T
         if track_flow:
             return res, flux_res
@@ -298,7 +298,7 @@ or set use_odespy=false
         
         '''Cycle through months m'''
         for m in range(0, ts):
-            print('Integrating month # %s') % (m)
+            print(('Integrating month # %s') % (m))
             current_season = mod(m, self.steps_per_period)
             current_matrix_csr = self.model.bigDlist[current_season]
             current_emissions = self.model.emission.get_emission(m,self.model)
@@ -317,11 +317,11 @@ or set use_odespy=false
             solver.set_initial_condition(current_y)
             no_sub_steps = 1
             substeplength = self.stepdef[current_season] 
-            print('\tSeason %d\t %d substeps of length %.5f hours')\
-                            % (current_season,no_sub_steps, substeplength)
+            print(('\tSeason %d\t %d substeps of length %.5f hours')\
+                            % (current_season,no_sub_steps, substeplength))
             te1=time.time()
             ts1=time.time()
-            print('\tIntegrating %i substeps: ' % no_sub_steps),
+            print(('\tIntegrating %i substeps: ' % no_sub_steps), end=' ')
             
             '''NOTE: Check if loopng over substeps cam be avoided (should always be 1 step) '''
             for i in range(0, no_sub_steps):
@@ -330,7 +330,7 @@ or set use_odespy=false
                 t=t[1]    
                 te1=time.time()
             
-            print('\n done with month %d  [%.3f s]')  % (m, (te1-ts1))
+            print(('\n done with month %d  [%.3f s]')  % (m, (te1-ts1)))
             
             
             if track_flow:
@@ -349,7 +349,7 @@ or set use_odespy=false
             """Stop timer"""
             te0=time.time()
 
-        print "time elapsed: %f minutes" % ((te0-ts0)/60.0)
+        print("time elapsed: %f minutes" % ((te0-ts0)/60.0))
         res=res.T
         
         if track_flow:

--- a/tempcorrect.py
+++ b/tempcorrect.py
@@ -31,7 +31,7 @@ def tempcorrect(par, compdict, chem):
     ##       then perfect persistence would be much easier to implement
 
     chem_spatial_dict={}
-    for k in compdict.keys():
+    for k in list(compdict.keys()):
         ## initialize record-array
         pa=zeros(par.shape, dtype=dtype([('k_reac','f8'), ('Kaw','f8'),
                                               ('Koa','f8'),('Kow','f8')]))
@@ -55,14 +55,14 @@ def tempcorrect(par, compdict, chem):
     ## weight degradation in air according to OH-radical concentration
     ## ATT : This special treatment of air1 and air2 should be generalized
     ## somehow.
-    if 1 in chem_spatial_dict.keys():
+    if 1 in list(chem_spatial_dict.keys()):
         chem_spatial_dict[1]['k_reac']*=par['OHair1'] # upper air
-    if 2 in chem_spatial_dict.keys():
+    if 2 in list(chem_spatial_dict.keys()):
         chem_spatial_dict[2]['k_reac']*=par['OHair2'] # lower air
-    if 8 in chem_spatial_dict.keys():
+    if 8 in list(chem_spatial_dict.keys()):
         chem_spatial_dict[8]['k_reac']*=par['OHair1'] # upper air coarse aerosol
-    if 9 in chem_spatial_dict.keys():
+    if 9 in list(chem_spatial_dict.keys()):
         chem_spatial_dict[9]['k_reac']*=par['OHair2'] # lower air fine aerosol 
-    if 10 in chem_spatial_dict.keys():
+    if 10 in list(chem_spatial_dict.keys()):
         chem_spatial_dict[10]['k_reac']*=par['OHair2'] # lower air coarse aerosol
     return(chem_spatial_dict)

--- a/validate.py
+++ b/validate.py
@@ -21,13 +21,14 @@ subdirectoy "vbaresults".
 from numpy import *
 import sys
 from scipy import sparse
-import cPickle
+import pickle
 import subprocess
 import os
 import shutil
 from pylab import *
 import BETRS
-reload(BETRS)
+import importlib
+importlib.reload(BETRS)
 from BETRS import *
 import helpers
 
@@ -43,11 +44,11 @@ import helpers
 def validate(level, chemicals):
     print('Validating BETR-Research for chemicals')
     print(chemicals)
-    print('at level {0:.3e}'.format(level))
+    print(('at level {0:.3e}'.format(level)))
     valid=True
     difflist=[]
     for chem in chemicals:
-        print('Calculating system matrices for chemical %d') % (chem)
+        print(('Calculating system matrices for chemical %d') % (chem))
         m=Model(chem,controlfile='control_validation.txt')
         shutil.copy(os.path.join('Output','default','matrixdump.cpk'),
                 os.path.join('Validation'))
@@ -55,7 +56,7 @@ def validate(level, chemicals):
         ## load BETRS-output
         fn=os.path.join('Output','default','matrixdump.cpk')
         f=open(fn,'r')
-        Dmatpy=cPickle.load(f)
+        Dmatpy=pickle.load(f)
         f.close()
 
         ## load BETR-VBA output
@@ -66,7 +67,7 @@ def validate(level, chemicals):
             sys.exit('Did not find the file {0:s}. Aborting !'.format(fnvba))
 
         for mo in arange(0,12):
-            print('comparing substance %s, month %i') % (chem,mo+1)
+            print(('comparing substance %s, month %i') % (chem,mo+1))
             Dres=Dmatpy[mo]
             ## get empty volume elements
             killidx=findemptycells(Dres)
@@ -101,10 +102,10 @@ def validate(level, chemicals):
             diff1=where(logical_and(Dres==0, Dvba!=0))
             diff2=where(logical_and(Dres!=0, Dvba==0))
             if diff1[0].size > 0 or diff2[0].size > 0:
-                print('Validation failed ! There are zeros in one matrix that'\
-                      +' are non-zero in the other:')
-                print('research == 0, vba != 0: {0:s}'.format(diff1))
-                print('research != 0, vba == 0: {0:s}'.format(diff2))
+                print(('Validation failed ! There are zeros in one matrix that'\
+                      +' are non-zero in the other:'))
+                print(('research == 0, vba != 0: {0:s}'.format(diff1)))
+                print(('research != 0, vba == 0: {0:s}'.format(diff2)))
                 valid=False
             else:
                 print('Test for equality of sparsity pattern: passed.')
@@ -116,23 +117,23 @@ def validate(level, chemicals):
             fromc=list(cell2regcomp(s1[1],m)[1])
             toc=list(cell2regcomp(s1[0],m)[1])
             cells=list(cell2regcomp(s1[0],m)[0])
-            ft=zip(fromc,toc)
+            ft=list(zip(fromc,toc))
             diffdict={}
             for i in enumerate(ft):
-                if diffdict.has_key(i[1]):
+                if i[1] in diffdict:
                     diffdict[i[1]].append(cells[i[0]])
                 else:
                     diffdict[i[1]]=[cells[i[0]]]
             if bool(diffdict):
-                print('Validation not passed, relative differences > {0:.3e}'\
-                      +' occured :'.format(level))
+                print(('Validation not passed, relative differences > {0:.3e}'\
+                      +' occured :'.format(level)))
                 print(diffdict)
                 print('erroneous from-to:')
-                print(unique(ft))
+                print((unique(ft)))
                 valid=False
             else:
-                print('Matices equal within rtol={0:.3e}'.format(level))
-    print(60*'*')
+                print(('Matices equal within rtol={0:.3e}'.format(level)))
+    print((60*'*'))
     if valid:
         print('Overall validation: PASSED')
     else:


### PR DESCRIPTION
This update makes BETR-Global compatible with Python3. As you likely know, python2 has been sunset as of [Jan 1, 2020](https://www.python.org/doc/sunset-python-2/). In addition, there are many cloud-based python3 environments that would make using BETR-Global easier if it supported Python3. This is an easy fix update, so I have taken the liberty of doing it.

To make BETR-Global compatible with Python3, I basically fixed a couple tabs and ran the 2to3 utility. When that was complete, I ran the tutorials bug fixing manually where necessary.  These were relatively small fixes (e.g., where numpy requires integer indexing and used to support floats).

I have attached a Jupyter Notebook (in a zip file), which can be uploaded to [Google Colab](https://colab.research.google.com/) and run. Note for testing purposes, I wanted it to run quickly. So, I have made the dynamic run just do two years. With this short dynamic run, the test notebook takes about 18 minutes to run. 

The test notebook shows spatial and temporal plots using `xarray`. Since my simple test is short, it does not sufficiently accumulate BDE209 in the ocean water. As a result, I only check the lower air and only focus on over land. With those caveats, the lower air concentrations look reasonable -- given the expected low-biases over water. 

[BETR4.zip](https://github.com/BETR-Global/BETR-Global-4.0/files/5822758/BETR4.zip)

I hope that these updates are useful.